### PR TITLE
Ability to round to nearest multiple of given integer

### DIFF
--- a/app/models/spree/calculator/percent_off_sale_price_calculator.rb
+++ b/app/models/spree/calculator/percent_off_sale_price_calculator.rb
@@ -10,7 +10,13 @@ module Spree
 
     def compute(sale_price)
       computed_price = (1.0 - sale_price.value.to_f) * sale_price.variant.price_in(sale_price.price.currency).original_price.to_f
-      return preferences[:round_number] ? computed_price.round.to_f : computed_price
+      if preferences[:round_to_nearest_multiple_of] && preferences[:round_to_nearest_multiple_of].integer?
+        (computed_price / preferences[:round_to_nearest_multiple_of]).ceil * preferences[:round_to_nearest_multiple_of]
+      elsif preferences[:round_number]
+        computed_price.round.to_f
+      else
+        computed_price
+      end
     end
 
     private

--- a/spec/models/price_spec.rb
+++ b/spec/models/price_spec.rb
@@ -49,6 +49,22 @@ describe Spree::Price do
     expect(price.original_price).to eql(19.99)
   end
 
+  it 'can round down a percent-off sale to nearest multiple of specified integer' do
+    price = create(:price)
+    price.put_on_sale 0.31, calculator_type: 'Spree::Calculator::PercentOffSalePriceCalculator', calculator_preferences: { round_number: true, round_to_nearest_multiple_of: 5 }
+
+    expect(price.price).to eql(15)
+    expect(price.original_price).to eql(19.99)
+  end
+
+  it 'can round up a percent-off sale to nearest multiple of specified integer' do
+    price = create(:price)
+    price.put_on_sale 0.39, calculator_type: 'Spree::Calculator::PercentOffSalePriceCalculator', calculator_preferences: { round_number: true, round_to_nearest_multiple_of: 5 }
+
+    expect(price.price).to eql(15)
+    expect(price.original_price).to eql(19.99)
+  end
+
   context 'calculating discount percentage' do
     it 'returns 0 if there\'s no original price' do
       price = create(:price)


### PR DESCRIPTION
## Outline
Adds the ability to round to the nearest multiple of a given integer when using the `PercentOffSalePriceCalculator`.

## Usage:
```
product = Spree::Product.first
product.put_on_sale(0.30, { 
  currencies: ['USD', 'GBP', 'EUR'], 
  calculator_type: 'Spree::Calculator::PercentOffSalePriceCalculator',
  calculator_preferences: { round_to_nearest_multiple_of: 5 } 
})
```