### PR TITLE
this fixes issue #2

### DIFF
--- a/app/models/spree/calculator/percent_off_sale_price_calculator.rb
+++ b/app/models/spree/calculator/percent_off_sale_price_calculator.rb
@@ -11,7 +11,7 @@ module Spree
     def compute(sale_price)
       computed_price = (1.0 - sale_price.value.to_f) * sale_price.variant.price_in(sale_price.price.currency).original_price.to_f
       if preferences[:round_to_nearest_multiple_of] && preferences[:round_to_nearest_multiple_of].integer?
-        (computed_price / preferences[:round_to_nearest_multiple_of]).ceil * preferences[:round_to_nearest_multiple_of]
+        (computed_price / preferences[:round_to_nearest_multiple_of]).round * preferences[:round_to_nearest_multiple_of]
       elsif preferences[:round_number]
         computed_price.round.to_f
       else

--- a/spec/models/price_spec.rb
+++ b/spec/models/price_spec.rb
@@ -51,15 +51,15 @@ describe Spree::Price do
 
   it 'can round down a percent-off sale to nearest multiple of specified integer' do
     price = create(:price)
-    price.put_on_sale 0.31, calculator_type: 'Spree::Calculator::PercentOffSalePriceCalculator', calculator_preferences: { round_number: true, round_to_nearest_multiple_of: 5 }
+    price.put_on_sale 0.4, calculator_type: 'Spree::Calculator::PercentOffSalePriceCalculator', calculator_preferences: { round_number: true, round_to_nearest_multiple_of: 5 }
 
-    expect(price.price).to eql(15)
+    expect(price.price).to eql(10)
     expect(price.original_price).to eql(19.99)
   end
 
   it 'can round up a percent-off sale to nearest multiple of specified integer' do
     price = create(:price)
-    price.put_on_sale 0.39, calculator_type: 'Spree::Calculator::PercentOffSalePriceCalculator', calculator_preferences: { round_number: true, round_to_nearest_multiple_of: 5 }
+    price.put_on_sale 0.3, calculator_type: 'Spree::Calculator::PercentOffSalePriceCalculator', calculator_preferences: { round_number: true, round_to_nearest_multiple_of: 5 }
 
     expect(price.price).to eql(15)
     expect(price.original_price).to eql(19.99)


### PR DESCRIPTION
uses `round` instead of `ceil` to ensure rounding handled correctly when matching nearest multiple of supplied integer.